### PR TITLE
make all things configurable

### DIFF
--- a/dnspython-hook.conf
+++ b/dnspython-hook.conf
@@ -1,0 +1,34 @@
+## configuration file for dehydrated's dnspython-hook
+# location:
+#  - $(pwd)/dnspython-hook.conf
+#  - /etc/dehydrated/dnspython-hook.conf
+#  - /usr/local/etc/dehydrated/dnspython-hook.conf
+#  OR provided via the '--config' cmdline flag
+
+[DEFAULT]
+## the nameserver that will serve the challenge
+#name_server_ip = 10.0.0.1
+## time-to-live for the challenge
+#TTL = 300
+## how long to wait to check whether the challenge is really served
+#wait = 5
+## verbosity of the script: use negative values to suppress more messages)
+#verbosity = 0
+
+## encryption key
+# you MUST have an encryption key to talk to a DNS-server.
+# if values are omitted from this config-file, they will instead be read
+# from the file specified in the DDNS_HOOK_KEY_FILE envvar.
+## name of the key
+key_name = testkey
+## base64-encoded value of the key
+key_secret = "R3HI8P6BKw9ZwXwN3VZKuQ=="
+## key-algorithm to use (bind9 only supports hmac-md5)
+#key_algorithm = hmac-md5
+
+###################################################
+# you can override values for a given domain
+#[example.com]
+#name_server_ip = 127.0.0.1
+#key_name = samplekey
+#key_secret = 6FMfj43Osz4lyb24OIe2iGEz9lf1llJO+lz=

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -46,7 +46,7 @@ logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
 
 # the default config-file
-configfile="dnspython.conf"
+configfiles=["dnspython.conf"]
 
 
 # Replace 10.0.0.1 with the IP address of your master server.
@@ -220,12 +220,12 @@ def read_config(args):
     except ImportError:
         import ConfigParser as configparser
 
-    cfgfile = configfile
+    cfgfiles = configfiles
     if args.config:
-        cfgfile = args.config
+        cfgfiles = args.config
 
     config = configparser.ConfigParser()
-    config.read(cfgfile)
+    config.read(cfgfiles)
 
     domain = args.domain[0]
     if domain in config:
@@ -255,7 +255,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-c", "--config",
-        help="Read options from configuration file [%s]" % (configfile),
+        help="Read options from configuration files [%s]" % (", ".join(configfiles)),
+        action='append',
         metavar="FILE")
     subparsers = parser.add_subparsers(help='sub-command help')
 

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -361,14 +361,7 @@ def parse_args():
     return (args.func, cfg)
 
 
-def main(hook_stage, domain_name, token):
-    logger.info(" + Dnsupdate.py executing " + hook_stage)
-
-    if hook_stage == 'deploy_challenge':
-        create_txt_record(domain_name, token)
-    if hook_stage == 'clean_challenge':
-        delete_txt_record(domain_name, token)
-
-
 if __name__ == '__main__':
-    main(sys.argv[1], sys.argv[2], sys.argv[4])
+    (fun, cfg) = parse_args()
+    fun(cfg)
+    sys.exit(0)

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -43,7 +43,10 @@ from dns.exception import DNSException
 
 # the default configuration
 defaults = {
-    "configfiles": ["dnspython.conf", ],
+    "configfiles": [
+        "/etc/dehydrated/dnspython.conf",
+        "/usr/local/etc/dehydrated/dnspython.conf",
+        "dnspython.conf", ],
     "name_server_ip": '10.0.0.1',
     "ttl": 300,
     "sleep": 5,

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -124,16 +124,16 @@ def create_txt_record(
         domain_name,
         keyring=keyring,
         keyalgorithm=keyalgorithm)
-    update.add('_acme-challenge', 300, 'TXT', token)
+    update.add('_acme-challenge', ttl, 'TXT', token)
 
     # Attempt to add a TXT record
     try:
-        response = dns.query.udp(update, name_server_ip, timeout=10)
+        response = dns.query.udp(update, name_server_ip, timeout=timeout)
     except DNSException as err:
         logger.error(err)
 
     # Wait for DNS record to propagate
-    time.sleep(5)
+    time.sleep(sleep)
 
     # Check if the TXT record was inserted
     try:
@@ -175,12 +175,12 @@ def delete_txt_record(
         keyalgorithm=keyalgorithm)
     update.delete('_acme-challenge', txt_record)
     try:
-        reponse = dns.query.udp(update, name_server_ip, timeout=10)
+        reponse = dns.query.udp(update, name_server_ip, timeout=timeout)
     except DNSException as err:
         logger.error(err)
 
     # Wait for DNS record to propagate
-    time.sleep(5)
+    time.sleep(sleep)
 
     # Check if the TXT record was successfully removed
     try:

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 # dnspython-hook - dns-01 Challenge Hook Script for dehydrated.sh
 #

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -325,7 +325,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-c", "--config",
-        help="Read options from configuration files [%s]" % (", ".join(defaults["configfiles"])),
+        help="Read options from configuration files [%s]"
+             % (", ".join(defaults["configfiles"])),
         action='append',
         metavar="FILE")
     parser.add_argument(

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -22,6 +22,13 @@
 #
 ############################################################################
 
+# callbacks
+# deploy_challenge <DOMAIN> <TOKEN_FILENAME> <TOKEN_VALUE>
+# clean_challenge <DOMAIN> <FILENAME> <TOKEN_VALUE>
+# deploy_cert <DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAINFILE> <CHAINFILE> <TIMESTAMP>
+# unchanged_cert DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAINFILE> <CHAINFILE>
+
+
 import os
 import sys
 import time

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -45,12 +45,13 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
 
-# the default config-file
-configfiles=["dnspython.conf"]
-
-
-# Replace 10.0.0.1 with the IP address of your master server.
-name_server_ip = '10.0.0.1'
+# the default configuration
+defaults = {
+    "configfiles": ["dnspython.conf", ],
+    "name_server_ip": '10.0.0.1',
+    "ttl": 300,
+    "sleep": 5,
+    }
 
 # If necessary, replace HMAC_MD5
 # with HMAC_SHA1, HMAC_SHA224, HMAC_SHA256, HMAC_SHA384, HMAC_SHA512
@@ -246,12 +247,15 @@ def ensure_config_dns(cfg):
     if "ttl" in cfg["config"]:
         cfg["config"]["ttl"] = int(float(cfg["config"]["ttl"]))
     else:
-        cfg["config"]["ttl"] = 300
+        cfg["config"]["ttl"] = defaults["ttl"]
 
     if "wait" in cfg["config"]:
         cfg["config"]["wait"] = float(cfg["config"]["wait"])
     else:
-        cfg["config"]["wait"] = 5
+        cfg["config"]["wait"] = defaults["sleep"]
+
+    if "name_server_ip" not in cfg["config"]:
+        cfg["config"]["name_server_ip"] = defaults["name_server_ip"]
 
     return cfg
 
@@ -261,7 +265,7 @@ def read_config(args):
     except ImportError:
         import ConfigParser as configparser
 
-    cfgfiles = configfiles
+    cfgfiles = defaults["configfiles"]
     if args.config:
         cfgfiles = args.config
 
@@ -296,7 +300,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-c", "--config",
-        help="Read options from configuration files [%s]" % (", ".join(configfiles)),
+        help="Read options from configuration files [%s]" % (", ".join(defaults["configfiles"])),
         action='append',
         metavar="FILE")
     subparsers = parser.add_subparsers(help='sub-command help')

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -60,10 +60,23 @@ keyalgorithm = dns.tsig.HMAC_MD5
 def get_key():
     import iscpy
     key_dict = {}
+    try:
+        import iscpy
+    except ImportError:
+        logging.exception("")
+        logging.fatal("The 'iscpy' module is required to read keys from isc-config file."
+                      "Alternatively set key_name/key_secret in the configuration file")
+        sys.exit(1)
     key_file = os.environ.get('DDNS_HOOK_KEY_FILE')
 
     # Open the key file for reading
-    f = open(key_file, 'rU')
+    try:
+        f = open(key_file, 'rU')
+    except IOError:
+        logging.exception("Unable to read isc-config file")
+        logging.fatal("Did you set the DDNS_HOOK_KEY_FILE env?"
+                      "Alternatively set key_name/key_secret in the configuration file")
+        sys.exit(1)
 
     # Parse the key file
     parsed_key_file = iscpy.ParseISCString(f.read())

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -44,9 +44,9 @@ from dns.exception import DNSException
 # the default configuration
 defaults = {
     "configfiles": [
-        "/etc/dehydrated/dnspython.conf",
-        "/usr/local/etc/dehydrated/dnspython.conf",
-        "dnspython.conf", ],
+        "/etc/dehydrated/dnspython-hook.conf",
+        "/usr/local/etc/dehydrated/dnspython-hook.conf",
+        "dnspython-hook.conf", ],
     "name_server_ip": '10.0.0.1',
     "ttl": 300,
     "sleep": 5,

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -3,7 +3,7 @@
 # dnspython-hook - dns-01 Challenge Hook Script for dehydrated.sh
 #
 # This script uses the dnspython API to create and delete TXT records
-# in order to prove ownership of a domain. 
+# in order to prove ownership of a domain.
 #
 # Copyright (C) 2016 Elizabeth Ferdman https://eferdman.github.io
 #
@@ -25,7 +25,7 @@
 import os
 import sys
 import time
-import logging 
+import logging
 import dns.resolver
 import dns.tsig
 import dns.tsigkeyring
@@ -49,10 +49,10 @@ def get_key():
     key_dict = {}
     key_file = os.environ.get('DDNS_HOOK_KEY_FILE')
 
-    # Open the key file for reading 
+    # Open the key file for reading
     f = open(key_file, 'rU')
 
-    # Parse the key file 
+    # Parse the key file
     parsed_key_file = iscpy.ParseISCString(f.read())
 
     # Grab the keyname, cut out the substring "key " and remove the extra quotes
@@ -74,7 +74,7 @@ def create_txt_record(domain_name, token):
     logger.info(" + Creating TXT record \"" + token + "\" for the domain _acme-challenge." + domain_name)
     update = dns.update.Update(domain_name, keyring=keyring, keyalgorithm=keyalgorithm)
     update.add('_acme-challenge', 300, 'TXT', token)
-    
+
     # Attempt to add a TXT record
     try:
         response = dns.query.udp(update, name_server_ip, timeout=10)
@@ -84,7 +84,7 @@ def create_txt_record(domain_name, token):
     # Wait for DNS record to propagate
     time.sleep(5)
 
-    # Check if the TXT record was inserted 
+    # Check if the TXT record was inserted
     try:
         answers = dns.resolver.query('_acme-challenge.' + domain_name, 'TXT')
     except DNSException as err:
@@ -101,7 +101,7 @@ def create_txt_record(domain_name, token):
 # Delete the TXT record using the dnspython API
 def delete_txt_record(domain_name, token):
     logger.info(" + Deleting TXT record \"" + token + "\" for the domain _acme-challenge." + domain_name)
-    
+
     # Retrieve the specific TXT record
     txt_record = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.TXT, token)
 
@@ -116,7 +116,7 @@ def delete_txt_record(domain_name, token):
     # Wait for DNS record to propagate
     time.sleep(5)
 
-    # Check if the TXT record was successfully removed    
+    # Check if the TXT record was successfully removed
     try:
         answers = dns.resolver.query('_acme-challenge.' + domain_name, 'TXT')
     except DNSException as err:
@@ -132,7 +132,7 @@ def delete_txt_record(domain_name, token):
 
 def main(hook_stage, domain_name, token):
     logger.info(" + Dnsupdate.py executing " + hook_stage)
-    
+
     if hook_stage == 'deploy_challenge':
         create_txt_record(domain_name, token)
     if hook_stage == 'clean_challenge':

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -200,14 +200,25 @@ def delete_txt_record(
 # callback to show the challenge via DNS
 def deploy_challenge(cfg):
     ensure_config_dns(cfg)
-    for c in cfg:
-        print("%s: %s" % (c, cfg[c]))
-    print("===")
+    create_txt_record(
+        cfg["args"]["domain"], cfg["args"]["token"],
+        cfg["config"]["name_server_ip"],
+        cfg["config"]["keyring"], cfg["config"]["keyalgorithm"],
+        ttl=cfg["config"]["ttl"],
+        sleep=cfg["config"]["wait"],
+        )
 
 
 # callback to clean the challenge from DNS
 def clean_challenge(cfg):
-    print(cfg)
+    ensure_config_dns(cfg)
+    delete_txt_record(
+        cfg["args"]["domain"], cfg["args"]["token"],
+        cfg["config"]["name_server_ip"],
+        cfg["config"]["keyring"], cfg["config"]["keyalgorithm"],
+        ttl=cfg["config"]["ttl"],
+        sleep=cfg["config"]["wait"],
+        )
 
 
 # callback to deploy the obtained certificate

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -49,6 +49,16 @@ defaults = {
     "sleep": 5,
     "loglevel": logging.WARN,
     }
+# valid key algorithms (but bind9 only supports hmac-md5)
+key_algorithms = {
+    "": dns.tsig.HMAC_MD5,
+    "hmac-md5": dns.tsig.HMAC_MD5,
+    "hmac-sha1": dns.tsig.HMAC_SHA1,
+    "hmac-sha224": dns.tsig.HMAC_SHA224,
+    "hmac-sha256": dns.tsig.HMAC_SHA256,
+    "hmac-sha384": dns.tsig.HMAC_SHA384,
+    "hmac-sha512": dns.tsig.HMAC_SHA512,
+    }
 
 # Configure some basic logging
 logger = logging.getLogger(__name__)
@@ -64,18 +74,6 @@ def set_verbosity(verbosity):
 
 
 set_verbosity(0)
-
-# If necessary, replace HMAC_MD5
-# with HMAC_SHA1, HMAC_SHA224, HMAC_SHA256, HMAC_SHA384, HMAC_SHA512
-key_algorithms = {
-    "": dns.tsig.HMAC_MD5,
-    "hmac-md5": dns.tsig.HMAC_MD5,
-    "hmac-sha1": dns.tsig.HMAC_SHA1,
-    "hmac-sha224": dns.tsig.HMAC_SHA224,
-    "hmac-sha256": dns.tsig.HMAC_SHA256,
-    "hmac-sha384": dns.tsig.HMAC_SHA384,
-    "hmac-sha512": dns.tsig.HMAC_SHA512,
-    }
 
 
 def get_key_algo(name='hmac-md5'):

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -89,23 +89,83 @@ def read_config():
         "-c", "--config",
         help="Read options from configuration file [%s]" % (configfile),
         metavar="FILE")
-    # stage can be: 'deploy_challenge', 'clean_challenge'
-    parser.add_argument(
-        'stage',
-        nargs=1,
-        help="stage in the certificate request process")
-    parser.add_argument(
-        'tokenfile',
-        nargs=1,
-        help="IGNORED")
-    parser.add_argument(
+    subparsers = parser.add_subparsers(help='sub-command help')
+
+    parser_deploychallenge = subparsers.add_parser('deploy_challenge', help='make ACME challenge available via DNS')
+    parser_deploychallenge.add_argument(
         'domain',
         nargs=1,
         help="domain name to request certificate for")
-    parser.add_argument(
+    parser_deploychallenge.add_argument(
+        'tokenfile',
+        nargs=1,
+        help="IGNORED")
+    parser_deploychallenge.add_argument(
         'token',
         nargs=1,
         help="ACME-provided token")
+
+    parser_cleanchallenge = subparsers.add_parser('clean_challenge', help='remove ACME challenge from DNS')
+    parser_cleanchallenge.add_argument(
+        'domain',
+        nargs=1,
+        help="domain name for which to remove cetificate challenge")
+    parser_cleanchallenge.add_argument(
+        'tokenfile',
+        nargs=1,
+        help="IGNORED")
+    parser_cleanchallenge.add_argument(
+        'token',
+        nargs=1,
+        help="ACME-provided token")
+
+    parser_deploycert = subparsers.add_parser('deploy_cert', help='deploy certificate obtained from ACME (IGNORED)')
+    parser_deploycert.add_argument(
+        'domain',
+        nargs=1,
+        help="domain name to deploy certificate for")
+    parser_deploycert.add_argument(
+        'keyfile',
+        nargs=1,
+        help="private certificate")
+    parser_deploycert.add_argument(
+        'certfile',
+        nargs=1,
+        help="public certificate")
+    parser_deploycert.add_argument(
+        'fullchainfile',
+        nargs=1,
+        help="full certificate chain")
+    parser_deploycert.add_argument(
+        'chainfile',
+        nargs=1,
+        help="certificate chain")
+    parser_deploycert.add_argument(
+        'timestamp',
+        nargs=1,
+        help="time stamp")
+
+    parser_unchangedcert = subparsers.add_parser('unchanged_cert', help='unchanged certificate obtained from ACME (IGNORED)')
+    parser_unchangedcert.add_argument(
+        'domain',
+        nargs=1,
+        help="domain name, for which the certificate hasn't changed")
+    parser_unchangedcert.add_argument(
+        'keyfile',
+        nargs=1,
+        help="private certificate")
+    parser_unchangedcert.add_argument(
+        'certfile',
+        nargs=1,
+        help="public certificate")
+    parser_unchangedcert.add_argument(
+        'fullchainfile',
+        nargs=1,
+        help="full certificate chain")
+    parser_unchangedcert.add_argument(
+        'chainfile',
+        nargs=1,
+        help="certificate chain")
 
     args = parser.parse_args()
     if args.config:

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -32,7 +32,6 @@ import dns.tsigkeyring
 import dns.update
 import dns.query
 from dns.exception import DNSException
-import iscpy
 
 # Configure some basic logging
 logger = logging.getLogger(__name__)
@@ -46,6 +45,7 @@ name_server_ip = '10.0.0.1'
 keyalgorithm = dns.tsig.HMAC_MD5
 
 def get_key():
+    import iscpy
     key_dict = {}
     key_file = os.environ.get('DDNS_HOOK_KEY_FILE')
 

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -54,7 +54,23 @@ name_server_ip = '10.0.0.1'
 
 # If necessary, replace HMAC_MD5
 # with HMAC_SHA1, HMAC_SHA224, HMAC_SHA256, HMAC_SHA384, HMAC_SHA512
-keyalgorithm = dns.tsig.HMAC_MD5
+key_algorithms = {
+    "": dns.tsig.HMAC_MD5,
+    "hmac-md5": dns.tsig.HMAC_MD5,
+    "hmac-sha1": dns.tsig.HMAC_SHA1,
+    "hmac-sha224": dns.tsig.HMAC_SHA224,
+    "hmac-sha256": dns.tsig.HMAC_SHA256,
+    "hmac-sha384": dns.tsig.HMAC_SHA384,
+    "hmac-sha512": dns.tsig.HMAC_SHA512,
+    }
+
+def get_key_algo(name='hmac-md5'):
+    try:
+        return key_algorithms[name]
+    except KeyError:
+        logging.exception("Invalid key-algorithm '%s'" % (name,))
+        logging.fatal("Only the following algorithms are allowed: %s" % (" ".join(key_algorithms.keys())))
+        sys.exit(1)
 
 
 def get_isc_key():

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -96,6 +96,7 @@ def read_config():
     subparsers = parser.add_subparsers(help='sub-command help')
 
     parser_deploychallenge = subparsers.add_parser('deploy_challenge', help='make ACME challenge available via DNS')
+    parser_deploychallenge.set_defaults(func=deploy_challenge)
     parser_deploychallenge.add_argument(
         'domain',
         nargs=1,
@@ -110,6 +111,7 @@ def read_config():
         help="ACME-provided token")
 
     parser_cleanchallenge = subparsers.add_parser('clean_challenge', help='remove ACME challenge from DNS')
+    parser_cleanchallenge.set_defaults(func=clean_challenge)
     parser_cleanchallenge.add_argument(
         'domain',
         nargs=1,
@@ -124,6 +126,7 @@ def read_config():
         help="ACME-provided token")
 
     parser_deploycert = subparsers.add_parser('deploy_cert', help='deploy certificate obtained from ACME (IGNORED)')
+    parser_deploycert.set_defaults(func=deploy_cert)
     parser_deploycert.add_argument(
         'domain',
         nargs=1,
@@ -150,6 +153,7 @@ def read_config():
         help="time stamp")
 
     parser_unchangedcert = subparsers.add_parser('unchanged_cert', help='unchanged certificate obtained from ACME (IGNORED)')
+    parser_unchangedcert.set_defaults(func=unchanged_cert)
     parser_unchangedcert.add_argument(
         'domain',
         nargs=1,

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -232,9 +232,15 @@ def ensure_config_dns(cfg):
 
     if "ttl" in cfg["config"]:
         cfg["config"]["ttl"] = int(float(cfg["config"]["ttl"]))
+    else:
+        cfg["config"]["ttl"] = 300
+
     if "wait" in cfg["config"]:
         cfg["config"]["wait"] = float(cfg["config"]["wait"])
+    else:
+        cfg["config"]["wait"] = 5
 
+    return cfg
 
 def read_config(args):
     try:

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -223,6 +223,12 @@ def ensure_config_dns(cfg):
     keyring = dns.tsigkeyring.from_text(keyringd)
     cfg["config"]["keyring"] = keyring
 
+    try:
+        algo = cfg["config"]["key_algorithm"]
+    except KeyError:
+        algo =""
+    algo = get_key_algo(algo)
+    cfg["config"]["keyalgorithm"] = algo
 
     if "ttl" in cfg["config"]:
         cfg["config"]["ttl"] = int(float(cfg["config"]["ttl"]))

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -41,8 +41,10 @@ logger.setLevel(logging.INFO)
 # Replace 10.0.0.1 with the IP address of your master server.
 name_server_ip = '10.0.0.1'
 
-# If necessary, replace HMAC_MD5 with HMAC_SHA1, HMAC_SHA224, HMAC_SHA256, HMAC_SHA384, HMAC_SHA512
+# If necessary, replace HMAC_MD5
+# with HMAC_SHA1, HMAC_SHA224, HMAC_SHA256, HMAC_SHA384, HMAC_SHA512
 keyalgorithm = dns.tsig.HMAC_MD5
+
 
 def get_key():
     import iscpy
@@ -55,7 +57,8 @@ def get_key():
     # Parse the key file
     parsed_key_file = iscpy.ParseISCString(f.read())
 
-    # Grab the keyname, cut out the substring "key " and remove the extra quotes
+    # Grab the keyname, cut out the substring "key "
+    # and remove the extra quotes
     key_name = parsed_key_file.keys()[0][4:].strip('\"')
 
     # Grab the secret key
@@ -65,14 +68,21 @@ def get_key():
 
     return key_dict
 
+
 keyring = dns.tsigkeyring.from_text(get_key())
 
+
 # Create a TXT record through the dnspython API
-# Example code at https://github.com/rthalley/dnspython/blob/master/examples/ddns.py
+# Example code at
+#  https://github.com/rthalley/dnspython/blob/master/examples/ddns.py
 def create_txt_record(domain_name, token):
 
-    logger.info(" + Creating TXT record \"" + token + "\" for the domain _acme-challenge." + domain_name)
-    update = dns.update.Update(domain_name, keyring=keyring, keyalgorithm=keyalgorithm)
+    logger.info(' + Creating TXT record "%s" for the domain _acme-challenge.%s'
+                % (token, domain_name))
+    update = dns.update.Update(
+        domain_name,
+        keyring=keyring,
+        keyalgorithm=keyalgorithm)
     update.add('_acme-challenge', 300, 'TXT', token)
 
     # Attempt to add a TXT record
@@ -98,15 +108,23 @@ def create_txt_record(domain_name, token):
             logger.info(" + TXT record not added.")
             sys.exit(1)
 
+
 # Delete the TXT record using the dnspython API
 def delete_txt_record(domain_name, token):
-    logger.info(" + Deleting TXT record \"" + token + "\" for the domain _acme-challenge." + domain_name)
+    logger.info(' + Deleting TXT record "%s" for the domain _acme-challenge.%s'
+                % (token, domain_name))
 
     # Retrieve the specific TXT record
-    txt_record = dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.TXT, token)
+    txt_record = dns.rdata.from_text(
+        dns.rdataclass.IN,
+        dns.rdatatype.TXT,
+        token)
 
     # Attempt to delete the TXT record
-    update = dns.update.Update(domain_name, keyring=keyring, keyalgorithm=keyalgorithm)
+    update = dns.update.Update(
+        domain_name,
+        keyring=keyring,
+        keyalgorithm=keyalgorithm)
     update.delete('_acme-challenge', txt_record)
     try:
         reponse = dns.query.udp(update, name_server_ip, timeout=10)
@@ -130,6 +148,7 @@ def delete_txt_record(domain_name, token):
         else:
             logger.info(" + TXT record successfully deleted.")
 
+
 def main(hook_stage, domain_name, token):
     logger.info(" + Dnsupdate.py executing " + hook_stage)
 
@@ -137,6 +156,7 @@ def main(hook_stage, domain_name, token):
         create_txt_record(domain_name, token)
     if hook_stage == 'clean_challenge':
         delete_txt_record(domain_name, token)
+
 
 if __name__ == '__main__':
     main(sys.argv[1], sys.argv[2], sys.argv[4])

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -76,6 +76,46 @@ def get_key():
     return key_dict
 
 
+def read_config():
+    import argparse
+    try:
+        import configparser
+    except ImportError:
+        import ConfigParser as configparser
+
+    configfile="dnspython.conf"
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-c", "--config",
+        help="Read options from configuration file [%s]" % (configfile),
+        metavar="FILE")
+    # stage can be: 'deploy_challenge', 'clean_challenge'
+    parser.add_argument(
+        'stage',
+        nargs=1,
+        help="stage in the certificate request process")
+    parser.add_argument(
+        'tokenfile',
+        nargs=1,
+        help="IGNORED")
+    parser.add_argument(
+        'domain',
+        nargs=1,
+        help="domain name to request certificate for")
+    parser.add_argument(
+        'token',
+        nargs=1,
+        help="ACME-provided token")
+
+    args = parser.parse_args()
+    if args.config:
+        configfile = args.config
+
+    config = configparser.ConfigParser()
+    config.read(configfile)
+
+    return config
+
 keyring = dns.tsigkeyring.from_text(get_key())
 
 

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -45,6 +45,10 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
 
+# the default config-file
+configfile="dnspython.conf"
+
+
 # Replace 10.0.0.1 with the IP address of your master server.
 name_server_ip = '10.0.0.1'
 

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -6,6 +6,7 @@
 # in order to prove ownership of a domain.
 #
 # Copyright (C) 2016 Elizabeth Ferdman https://eferdman.github.io
+# Copyright (C) 2016 IOhannes m zmölnig <zmoelnig@iem.at>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -25,7 +25,7 @@
 # callbacks
 # deploy_challenge <DOMAIN> <TOKEN_FILENAME> <TOKEN_VALUE>
 # clean_challenge <DOMAIN> <FILENAME> <TOKEN_VALUE>
-# deploy_cert <DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAINFILE> <CHAINFILE> <TIMESTAMP>
+# deploy_cert <DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAIN> <CHAINFILE> <TIMESTAMP>
 # unchanged_cert DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAINFILE> <CHAINFILE>
 
 
@@ -54,12 +54,14 @@ defaults = {
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 
+
 def set_verbosity(verbosity):
     oldlevel = logger.getEffectiveLevel()
     level = int(defaults["loglevel"] - (10 * verbosity))
     if level <= 0:
         level = 1
     logger.setLevel(level)
+
 
 set_verbosity(0)
 
@@ -74,6 +76,7 @@ key_algorithms = {
     "hmac-sha384": dns.tsig.HMAC_SHA384,
     "hmac-sha512": dns.tsig.HMAC_SHA512,
     }
+
 
 def get_key_algo(name='hmac-md5'):
     try:
@@ -213,6 +216,7 @@ def delete_txt_record(
         else:
             logger.info(" + TXT record successfully deleted.")
 
+
 # callback to show the challenge via DNS
 def deploy_challenge(cfg):
     ensure_config_dns(cfg)
@@ -248,11 +252,16 @@ def deploy_cert(cfg):
 def unchanged_cert(cfg):
     pass
 
+
 def ensure_config_dns(cfg):
     """make sure that the configuration can be used to update the DNS
 (e.g. read rndc-key if missing; fix some values if present)
 """
-    # (str)key_name, (str)key_secret, (str)name_server_ip, (int)ttl, (float)wait
+    # (str)key_name
+    # (str)key_secret
+    # (str)name_server_ip
+    # (int)ttl
+    # (float)wait
 
     try:
         key_name = cfg["config"]["key_name"]
@@ -260,14 +269,14 @@ def ensure_config_dns(cfg):
     except KeyError:
         (key_name, key_secret) = get_isc_key()
 
-    keyringd={key_name: key_secret}
+    keyringd = {key_name: key_secret}
     keyring = dns.tsigkeyring.from_text(keyringd)
     cfg["config"]["keyring"] = keyring
 
     try:
         algo = cfg["config"]["key_algorithm"]
     except KeyError:
-        algo =""
+        algo = ""
     algo = get_key_algo(algo)
     cfg["config"]["keyalgorithm"] = algo
 
@@ -285,6 +294,7 @@ def ensure_config_dns(cfg):
         cfg["config"]["name_server_ip"] = defaults["name_server_ip"]
 
     return cfg
+
 
 def read_config(args):
     try:
@@ -313,17 +323,18 @@ def read_config(args):
 
     d = dict()
     for c in config:
-        d[c]=config[c]
+        d[c] = config[c]
     result["config"] = d
 
     d = dict()
     args = vars(args)
     for c in args:
         if type(args[c]) is list:
-            d[c]=args[c][0]
+            d[c] = args[c][0]
     result["args"] = d
 
     return result
+
 
 def parse_args():
     import argparse
@@ -346,7 +357,9 @@ def parse_args():
 
     subparsers = parser.add_subparsers(help='sub-command help')
 
-    parser_deploychallenge = subparsers.add_parser('deploy_challenge', help='make ACME challenge available via DNS')
+    parser_deploychallenge = subparsers.add_parser(
+        'deploy_challenge',
+        help='make ACME challenge available via DNS')
     parser_deploychallenge.set_defaults(func=deploy_challenge)
     parser_deploychallenge.add_argument(
         'domain',
@@ -361,7 +374,9 @@ def parse_args():
         nargs=1,
         help="ACME-provided token")
 
-    parser_cleanchallenge = subparsers.add_parser('clean_challenge', help='remove ACME challenge from DNS')
+    parser_cleanchallenge = subparsers.add_parser(
+        'clean_challenge',
+        help='remove ACME challenge from DNS')
     parser_cleanchallenge.set_defaults(func=clean_challenge)
     parser_cleanchallenge.add_argument(
         'domain',
@@ -376,7 +391,9 @@ def parse_args():
         nargs=1,
         help="ACME-provided token")
 
-    parser_deploycert = subparsers.add_parser('deploy_cert', help='deploy certificate obtained from ACME (IGNORED)')
+    parser_deploycert = subparsers.add_parser(
+        'deploy_cert',
+        help='deploy certificate obtained from ACME (IGNORED)')
     parser_deploycert.set_defaults(func=deploy_cert)
     parser_deploycert.add_argument(
         'domain',
@@ -403,7 +420,9 @@ def parse_args():
         nargs=1,
         help="time stamp")
 
-    parser_unchangedcert = subparsers.add_parser('unchanged_cert', help='unchanged certificate obtained from ACME (IGNORED)')
+    parser_unchangedcert = subparsers.add_parser(
+        'unchanged_cert',
+        help='unchanged certificate obtained from ACME (IGNORED)')
     parser_unchangedcert.set_defaults(func=unchanged_cert)
     parser_unchangedcert.add_argument(
         'domain',

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -110,8 +110,14 @@ def get_isc_key():
 # Create a TXT record through the dnspython API
 # Example code at
 #  https://github.com/rthalley/dnspython/blob/master/examples/ddns.py
-def create_txt_record(domain_name, token):
-
+def create_txt_record(
+        domain_name, token,
+        name_server_ip,
+        keyring, keyalgorithm=dns.tsig.HMAC_MD5,
+        ttl=300,
+        sleep=5,
+        timeout=10
+        ):
     logger.info(' + Creating TXT record "%s" for the domain _acme-challenge.%s'
                 % (token, domain_name))
     update = dns.update.Update(
@@ -145,7 +151,14 @@ def create_txt_record(domain_name, token):
 
 
 # Delete the TXT record using the dnspython API
-def delete_txt_record(domain_name, token):
+def delete_txt_record(
+        domain_name, token,
+        name_server_ip,
+        keyring, keyalgorithm=dns.tsig.HMAC_MD5,
+        ttl=300,
+        sleep=5,
+        timeout=10
+        ):
     logger.info(' + Deleting TXT record "%s" for the domain _acme-challenge.%s'
                 % (token, domain_name))
 


### PR DESCRIPTION
this is a major PR that refactors much of the code.

my main motivation was:
- only depend on python modules available within Debian (jessie) (installed via `apt`, not via `pip`)
- remove any hardcoded values from the sources (e.g. i do *not* want to modify the source-code in order to tell the script where to find the DNS-server.
- proper help

### less dependencies
your current implementation basically has two dependencies: `dnspython` and `iscpy`.
while the former is in Debian, the latter is not.
however, `iscpy` is only used to parse the rndc-key file: since my target application has the script and the nameserver (bind9) run on different systems, there is not so much value in sharing a key-file.
i could live well with a different (simple) fileformat, e.g. a bog standard `configfile`.

The current implementation uses the config-file mechanism (see belog), and if it cannot find any key-specifications therein, it will fall back to the original mechanism of reading a keyfile in the `DDNS_HOOK_KEY_FILE` (however, it will *only* `import iscpy` if it actually required)

### configfile
separating program code from user-configurable data, using the standard `configparser` module (`INI`-style config files).
this allows to provide *DEFAULT* values for the remote nameserver, the key,... and *also* allows to override these values on a per-domain basis.

see https://github.com/umlaeute/dnspython-hook/issues/1 and the `dnspython-hook.conf` example file.

the default configuration files used are:
- $(pwd)/dnspython-hook.conf
- /etc/dehydrate/dnspython-hook.conf
- /usr/local/etc/dehydrate/dnspython-hook.conf

allowing to provide site-wide configuration.

### commandline flags
for automatic documentation and cmdline flag validation, use `argparse`.
there are also some additional cmdline-flags (e.g. `--verbose` to raise verbosity, `--config` to provide alternative config-files), which make it useful for debugging (though probably less so for deployments)