### PR TITLE
hook chain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ with default values in the `[DEFAULT]` section.
 The following parameters can be set:
 - `name_server_ip` the DNS server IP that will serve the ACME challenge (**required**)
 - `TTL` time-to-live value for the challenge (default: *300*)
-- `wait` time - in seconds - to wait before verifying that the challenge is really deployed/deleted; use negative values to skip the check (default: *300*)
+- `wait` time - in seconds - to wait before verifying that the challenge is really deployed/deleted; use negative values to skip the check (default: *5*)
 - `verbosity` verbosity of the script: use negative values to suppress more messages (default: *0*)
 - `key_name` name of the key to use for authentication with the DNS server (**required**, see [below](#using-an-extra-key-file))
 - `key_secret` the base64-encoded key secret (**required**, see [below](#using-an-extra-key-file))

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This repository contains a python hook for the `dehydrated.sh` project, a Let's Encrypt/ACME client implemented as a shell script. This hook uses the dnspython API to perform dynamic DNS updates and queries to verify. The DNS challenge is outlined in the [ACME protocol](https://letsencrypt.github.io/acme-spec/#rfc.section.7.4). To successfully complete this challenge, the client creates a temporary TXT record containing a secret token for the given domain name, thereby proving ownership of the domain. 
 
 ## Required Python libraries
-* [iscpy](https://pypi.python.org/pypi/iscpy) - an ISC config file parser
 * [dnspython](http://www.dnspython.org/) - a DNS toolkit used for queries, zone transfers, and dynamic updates
+* (optional) [iscpy](https://pypi.python.org/pypi/iscpy) - an ISC config file parser (only needed when reading keys from an extra file)
 
 ## Installation
 Download the files for installation
@@ -14,14 +14,44 @@ Download the files for installation
   $ mkdir -p dehydrated/hooks/dnspython
   $ git clone https://github.com/eferdman/dnspython-hook.git dehydrated/hooks/dnspython
 ```
+
 ## Configuration
-The script reads the name of the key file from the environmental variable `DDNS_HOOK_KEY_FILE`
+The script reads a configuration file as specified via the cmdline (using the `--config` flag),
+falling back to these default config files:
+- `$(pwd)/dnspython-hook.conf`
+- `/etc/dehydrate/dnspython-hook.conf`
+- `/usr/local/etc/dehydrate/dnspython-hook.conf`
+
+The configuration file uses a simple `INI`-style syntax,
+where you can set the parameters for each domain separately (by creating a section named after the domain),
+with default values in the `[DEFAULT]` section.
+
+The following parameters can be set:
+- `name_server_ip` the DNS server IP that will serve the ACME challenge (**required**)
+- `TTL` time-to-live value for the challenge (default: *300*)
+- `wait` time - in seconds - to wait before verifying that the challenge is really deployed/deleted; use negative values to skip the check (default: *300*)
+- `verbosity` verbosity of the script: use negative values to suppress more messages (default: *0*)
+- `key_name` name of the key to use for authentication with the DNS server (**required**, see below)
+- `key_secret` the base64-encoded key secret (**required**, see below)
+- `key_algorithm` the hashing algorithm of the key (default: *hmac-md5*)
+
+A complete example can be found in the `dnspython-hook.conf` file.
+
+### Using an extra key file
+If you do not want to specify key name and key secret in the config file,
+you can provide that information in an extra file.
+
+The script reads the name of this key file from the environmental variable `DDNS_HOOK_KEY_FILE`
 
 ``` sh
   $ export DDNS_HOOK_KEY_FILE="path/to/key/file.key"
 ```
-Replace the variable `name_server_ip` with the ip address of your master server.
-Replace the variable `keyalgorithm` if using one other than hmac-md5
+
+The file must be formatted in an [rndc/bind](https://ftp.isc.org/isc/bind9/cur/9.9/doc/arm/man.rndc.conf.html) compatible way.
+
+Only when using *this* method for acquiring the key,
+you must have [iscpy](https://pypi.python.org/pypi/iscpy) installed.
+
 
 ## Usage
 See the [dehydrated script](https://github.com/lukas2511/dehydrated) for more options.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ The following parameters can be set:
 - `TTL` time-to-live value for the challenge (default: *300*)
 - `wait` time - in seconds - to wait before verifying that the challenge is really deployed/deleted; use negative values to skip the check (default: *300*)
 - `verbosity` verbosity of the script: use negative values to suppress more messages (default: *0*)
-- `key_name` name of the key to use for authentication with the DNS server (**required**, see below)
-- `key_secret` the base64-encoded key secret (**required**, see below)
+- `key_name` name of the key to use for authentication with the DNS server (**required**, see [below](#using-an-extra-key-file))
+- `key_secret` the base64-encoded key secret (**required**, see [below](#using-an-extra-key-file))
 - `key_algorithm` the hashing algorithm of the key (default: *hmac-md5*)
 
 A complete example can be found in the `dnspython-hook.conf` file.

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -539,6 +539,7 @@ def parse_args():
 
 
 if __name__ == '__main__':
-    (fun, cfg) = parse_args()
-    fun(cfg)
+    (fun, cfgs) = parse_args()
+    for cfg in cfgs:
+        fun(cfg)
     sys.exit(0)

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -348,21 +348,23 @@ e.g. [{'domain': 'example.com', 'tokenfile': '-', 'token': 'secret',
     # args has the sub-command arguments as lists,
     #  because they can be given multiple times (hook-chain)
     # we zip these dictionaries-of-lists into a list-of-dictionaries,
-    #  and then iterate over the list, filling in additional info from the config
+    #  and then iterate over the list, filling in more info from the config
 
     # remove some unwanted keys
-    argdict = dict((k, v) for k, v in vars(args).items() if not k.startswith("_"))
-    for k in ['config',]:
+    argdict = dict((k, v)
+                   for k, v in vars(args).items()
+                   if not k.startswith("_"))
+    for k in ['config', ]:
         try:
             del argdict[k]
         except KeyError:
             pass
 
     # zip the dict-of-lists int o list-of-dicts
-    result = [_ for _ in
-                  map(dict, zip(*[[(k, v[0]) for v in value]
-                                      for k, value in argdict.items()
-                                      if type(value) is list]))]
+    result = [_
+              for _ in map(dict, zip(*[[(k, v[0]) for v in value]
+                                       for k, value in argdict.items()
+                                       if type(value) is list]))]
 
     # fill in the values from the configfile
     for res in result:
@@ -411,7 +413,9 @@ def parse_args():
     parser_deploychallenge = subparsers.add_parser(
         'deploy_challenge',
         help='make ACME challenge available via DNS')
-    parser_deploychallenge.set_defaults(_func=deploy_challenge, _parser=parser_deploychallenge)
+    parser_deploychallenge.set_defaults(
+        _func=deploy_challenge,
+        _parser=parser_deploychallenge)
     parser_deploychallenge.add_argument(
         'domain',
         nargs=1, action='append',
@@ -434,7 +438,9 @@ def parse_args():
     parser_cleanchallenge = subparsers.add_parser(
         'clean_challenge',
         help='remove ACME challenge from DNS')
-    parser_cleanchallenge.set_defaults(_func=clean_challenge, _parser=parser_cleanchallenge)
+    parser_cleanchallenge.set_defaults(
+        _func=clean_challenge,
+        _parser=parser_cleanchallenge)
     parser_cleanchallenge.add_argument(
         'domain',
         nargs=1, action='append',
@@ -457,7 +463,9 @@ def parse_args():
     parser_deploycert = subparsers.add_parser(
         'deploy_cert',
         help='deploy certificate obtained from ACME (UNIMPLEMENTED)')
-    parser_deploycert.set_defaults(_func=deploy_cert, _parser=parser_deploycert)
+    parser_deploycert.set_defaults(
+        _func=deploy_cert,
+        _parser=parser_deploycert)
     parser_deploycert.add_argument(
         'domain',
         nargs=1, action='append',
@@ -486,7 +494,9 @@ def parse_args():
     parser_unchangedcert = subparsers.add_parser(
         'unchanged_cert',
         help='unchanged certificate obtained from ACME (IGNORED)')
-    parser_unchangedcert.set_defaults(_func=unchanged_cert, _parser=parser_unchangedcert)
+    parser_unchangedcert.set_defaults(
+        _func=unchanged_cert,
+        _parser=parser_unchangedcert)
     parser_unchangedcert.add_argument(
         'domain',
         nargs=1, action='append',
@@ -511,9 +521,9 @@ def parse_args():
     args = parser.parse_args()
     try:
         while(args._extra[0]):
-            extra=args._extra[0]
-            args._extra=[]
-            args=args._parser.parse_args(extra, args)
+            extra = args._extra[0]
+            args._extra = []
+            args = args._parser.parse_args(extra, args)
     except AttributeError:
         # no '_extra' attribute in this sub-parser
         pass

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -140,7 +140,7 @@ def create_txt_record(
     logger.info(' + Creating TXT record "%s" for the domain _acme-challenge.%s'
                 % (token, domain_name))
 
-    domain_list = ['_acme_challenge'] + domain_name.split('.')
+    domain_list = ['_acme-challenge'] + domain_name.split('.')
     for i in range(1, len(domain_list)):
         update = dns.update.Update(
             '.'.join(domain_list[i:]),
@@ -201,7 +201,7 @@ def delete_txt_record(
         dns.rdatatype.TXT,
         token)
 
-    domain_list = ['_acme_challenge'] + domain_name.split('.')
+    domain_list = ['_acme-challenge'] + domain_name.split('.')
     for i in range(1, len(domain_list)):
         # Attempt to delete the TXT record
         update = dns.update.Update(

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -376,21 +376,14 @@ e.g. [{'domain': 'example.com', 'tokenfile': '-', 'token': 'secret',
         for c in cfg:
             res[c] = cfg[c]
 
-        # special handling of 'verbosity', which can be overridden from the cmdline
-        try:
-            del res['verbosity']
-        except KeyError:
-            pass
-        verbosity = args.verbose
-        if args.verbose is not None:
-            res['verbosity'] = args.verbose
-        elif "verbosity" in cfg:
-            res['verbosity'] = float(cfg["verbosity"])
-
-        try:
-            set_verbosity(res['verbosity'])
-        except KeyError:
-            pass
+        # special handling of 'verbosity':
+        # base_verbosity (configfile) + offset (cmdline)
+        verbosity = 0
+        if args.verbose:
+            verbosity += args.verbose
+        if "verbosity" in cfg:
+            verbosity += float(cfg["verbosity"])
+        res['verbosity'] = verbosity
 
     return result
 

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -153,6 +153,9 @@ def create_txt_record(
         logger.error(err)
 
     # Wait for DNS record to propagate
+    if (sleep < 0):
+        return
+
     time.sleep(sleep)
 
     # Check if the TXT record was inserted
@@ -202,6 +205,8 @@ def delete_txt_record(
         logger.error("Error deleting TXT record")
 
     # Wait for DNS record to propagate
+    if (sleep < 0):
+        return
     time.sleep(sleep)
 
     # Check if the TXT record was successfully removed

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -80,6 +80,17 @@ def set_verbosity(verbosity):
 set_verbosity(0)
 
 
+def post_hook(name, cfg, args):
+    key = "post_%s" % (name,)
+    if key in cfg:
+        import subprocess
+        callargs = [cfg[key], name]
+        for a in args:
+            callargs += [cfg[a]]
+        logger.info(' + Calling post %s hook: %s' % (name, ' '.join(callargs)))
+        subprocess.call(callargs)
+
+
 def get_key_algo(name='hmac-md5'):
     try:
         return key_algorithms[name]
@@ -253,6 +264,7 @@ def deploy_challenge(cfg):
         ttl=cfg["ttl"],
         sleep=cfg["wait"],
         )
+    post_hook('deploy_challenge', cfg, ['domain', 'tokenfile', 'token'])
 
 
 # callback to clean the challenge from DNS
@@ -265,18 +277,25 @@ def clean_challenge(cfg):
         ttl=cfg["ttl"],
         sleep=cfg["wait"],
         )
+    post_hook('clean_challenge', cfg, ['domain', 'tokenfile', 'token'])
 
 
 # callback to deploy the obtained certificate
 # (currently unimplemented)
 def deploy_cert(cfg):
-    pass
+    post_hook(
+        'deploy_cert', cfg,
+        ['domain',
+         'keyfile', 'certfile',
+         'fullchainfile', 'chainfile', 'timestamp'])
 
 
 # callback when the certificate has not changed
 # (currently unimplemented)
 def unchanged_cert(cfg):
-    pass
+    post_hook(
+        'unchanged_cert', cfg,
+        ['domain', 'keyfile', 'certfile', 'fullchainfile', 'chainfile'])
 
 
 def ensure_config_dns(cfg):

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -387,92 +387,113 @@ def parse_args():
     parser_deploychallenge = subparsers.add_parser(
         'deploy_challenge',
         help='make ACME challenge available via DNS')
-    parser_deploychallenge.set_defaults(func=deploy_challenge)
+    parser_deploychallenge.set_defaults(func=deploy_challenge, parser=parser_deploychallenge)
     parser_deploychallenge.add_argument(
         'domain',
-        nargs=1,
+        nargs=1, action='append',
         help="domain name to request certificate for")
     parser_deploychallenge.add_argument(
         'tokenfile',
-        nargs=1,
+        nargs=1, action='append',
         help="IGNORED")
     parser_deploychallenge.add_argument(
         'token',
-        nargs=1,
+        nargs=1, action='append',
         help="ACME-provided token")
+    parser_deploychallenge.add_argument(
+        'extra',
+        nargs='*',
+        metavar='...',
+        action='append',
+        help="domain1 tokenfile1 token1 ...")
 
     parser_cleanchallenge = subparsers.add_parser(
         'clean_challenge',
         help='remove ACME challenge from DNS')
-    parser_cleanchallenge.set_defaults(func=clean_challenge)
+    parser_cleanchallenge.set_defaults(func=clean_challenge, parser=parser_cleanchallenge)
     parser_cleanchallenge.add_argument(
         'domain',
-        nargs=1,
+        nargs=1, action='append',
         help="domain name for which to remove cetificate challenge")
     parser_cleanchallenge.add_argument(
         'tokenfile',
-        nargs=1,
+        nargs=1, action='append',
         help="IGNORED")
     parser_cleanchallenge.add_argument(
         'token',
-        nargs=1,
+        nargs=1, action='append',
         help="ACME-provided token")
+    parser_cleanchallenge.add_argument(
+        'extra',
+        nargs='*',
+        metavar='...',
+        action='append',
+        help="domain1 tokenfile1 token1 ...")
 
     parser_deploycert = subparsers.add_parser(
         'deploy_cert',
-        help='deploy certificate obtained from ACME (IGNORED)')
-    parser_deploycert.set_defaults(func=deploy_cert)
+        help='deploy certificate obtained from ACME (UNIMPLEMENTED)')
+    parser_deploycert.set_defaults(func=deploy_cert, parser=parser_deploycert)
     parser_deploycert.add_argument(
         'domain',
-        nargs=1,
+        nargs=1, action='append',
         help="domain name to deploy certificate for")
     parser_deploycert.add_argument(
         'keyfile',
-        nargs=1,
+        nargs=1, action='append',
         help="private certificate")
     parser_deploycert.add_argument(
         'certfile',
-        nargs=1,
+        nargs=1, action='append',
         help="public certificate")
     parser_deploycert.add_argument(
         'fullchainfile',
-        nargs=1,
+        nargs=1, action='append',
         help="full certificate chain")
     parser_deploycert.add_argument(
         'chainfile',
-        nargs=1,
+        nargs=1, action='append',
         help="certificate chain")
     parser_deploycert.add_argument(
         'timestamp',
-        nargs=1,
+        nargs=1, action='append',
         help="time stamp")
 
     parser_unchangedcert = subparsers.add_parser(
         'unchanged_cert',
         help='unchanged certificate obtained from ACME (IGNORED)')
-    parser_unchangedcert.set_defaults(func=unchanged_cert)
+    parser_unchangedcert.set_defaults(func=unchanged_cert, parser=parser_unchangedcert)
     parser_unchangedcert.add_argument(
         'domain',
-        nargs=1,
+        nargs=1, action='append',
         help="domain name, for which the certificate hasn't changed")
     parser_unchangedcert.add_argument(
         'keyfile',
-        nargs=1,
+        nargs=1, action='append',
         help="private certificate")
     parser_unchangedcert.add_argument(
         'certfile',
-        nargs=1,
+        nargs=1, action='append',
         help="public certificate")
     parser_unchangedcert.add_argument(
         'fullchainfile',
-        nargs=1,
+        nargs=1, action='append',
         help="full certificate chain")
     parser_unchangedcert.add_argument(
         'chainfile',
-        nargs=1,
+        nargs=1, action='append',
         help="certificate chain")
 
     args = parser.parse_args()
+    try:
+        while(args.extra[0]):
+            extra=args.extra[0]
+            args.extra=[]
+            args=args.parser.parse_args(extra, args)
+    except AttributeError:
+        # no 'extra' attribute in this sub-parser
+        pass
+
     verbosity = args.verbose - args.quiet
     args.verbose = None
     args.quiet = None

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -71,7 +71,6 @@ logger.addHandler(logging.StreamHandler())
 
 
 def set_verbosity(verbosity):
-    oldlevel = logger.getEffectiveLevel()
     level = int(defaults["loglevel"] - (10 * verbosity))
     if level <= 0:
         level = 1

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -313,7 +313,7 @@ def read_config(args):
     config.read(cfgfiles)
 
     domain = args.domain[0]
-    if domain in config:
+    if domain in config.sections():
         config = config[domain]
     else:
         config = config.defaults()

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -248,11 +248,11 @@ def delete_txt_record(
 def deploy_challenge(cfg):
     ensure_config_dns(cfg)
     create_txt_record(
-        cfg["args"]["domain"], cfg["args"]["token"],
-        cfg["config"]["name_server_ip"],
-        cfg["config"]["keyring"], cfg["config"]["keyalgorithm"],
-        ttl=cfg["config"]["ttl"],
-        sleep=cfg["config"]["wait"],
+        cfg["domain"], cfg["token"],
+        cfg["name_server_ip"],
+        cfg["keyring"], cfg["keyalgorithm"],
+        ttl=cfg["ttl"],
+        sleep=cfg["wait"],
         )
 
 
@@ -260,11 +260,11 @@ def deploy_challenge(cfg):
 def clean_challenge(cfg):
     ensure_config_dns(cfg)
     delete_txt_record(
-        cfg["args"]["domain"], cfg["args"]["token"],
-        cfg["config"]["name_server_ip"],
-        cfg["config"]["keyring"], cfg["config"]["keyalgorithm"],
-        ttl=cfg["config"]["ttl"],
-        sleep=cfg["config"]["wait"],
+        cfg["domain"], cfg["token"],
+        cfg["name_server_ip"],
+        cfg["keyring"], cfg["keyalgorithm"],
+        ttl=cfg["ttl"],
+        sleep=cfg["wait"],
         )
 
 
@@ -291,34 +291,34 @@ def ensure_config_dns(cfg):
     # (float)wait
 
     try:
-        key_name = cfg["config"]["key_name"]
-        key_secret = cfg["config"]["key_secret"]
+        key_name = cfg["key_name"]
+        key_secret = cfg["key_secret"]
     except KeyError:
         (key_name, key_secret) = get_isc_key()
 
     keyringd = {key_name: key_secret}
     keyring = dns.tsigkeyring.from_text(keyringd)
-    cfg["config"]["keyring"] = keyring
+    cfg["keyring"] = keyring
 
     try:
-        algo = cfg["config"]["key_algorithm"]
+        algo = cfg["key_algorithm"]
     except KeyError:
         algo = ""
     algo = get_key_algo(algo)
-    cfg["config"]["keyalgorithm"] = algo
+    cfg["keyalgorithm"] = algo
 
-    if "ttl" in cfg["config"]:
-        cfg["config"]["ttl"] = int(float(cfg["config"]["ttl"]))
+    if "ttl" in cfg:
+        cfg["ttl"] = int(float(cfg["ttl"]))
     else:
-        cfg["config"]["ttl"] = defaults["ttl"]
+        cfg["ttl"] = defaults["ttl"]
 
-    if "wait" in cfg["config"]:
-        cfg["config"]["wait"] = float(cfg["config"]["wait"])
+    if "wait" in cfg:
+        cfg["wait"] = float(cfg["wait"])
     else:
-        cfg["config"]["wait"] = defaults["sleep"]
+        cfg["wait"] = defaults["sleep"]
 
-    if "name_server_ip" not in cfg["config"]:
-        cfg["config"]["name_server_ip"] = defaults["name_server_ip"]
+    if "name_server_ip" not in cfg:
+        cfg["name_server_ip"] = defaults["name_server_ip"]
 
     return cfg
 

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -387,7 +387,7 @@ def parse_args():
     parser_deploychallenge = subparsers.add_parser(
         'deploy_challenge',
         help='make ACME challenge available via DNS')
-    parser_deploychallenge.set_defaults(func=deploy_challenge, parser=parser_deploychallenge)
+    parser_deploychallenge.set_defaults(_func=deploy_challenge, _parser=parser_deploychallenge)
     parser_deploychallenge.add_argument(
         'domain',
         nargs=1, action='append',
@@ -401,7 +401,7 @@ def parse_args():
         nargs=1, action='append',
         help="ACME-provided token")
     parser_deploychallenge.add_argument(
-        'extra',
+        '_extra',
         nargs='*',
         metavar='...',
         action='append',
@@ -410,7 +410,7 @@ def parse_args():
     parser_cleanchallenge = subparsers.add_parser(
         'clean_challenge',
         help='remove ACME challenge from DNS')
-    parser_cleanchallenge.set_defaults(func=clean_challenge, parser=parser_cleanchallenge)
+    parser_cleanchallenge.set_defaults(_func=clean_challenge, _parser=parser_cleanchallenge)
     parser_cleanchallenge.add_argument(
         'domain',
         nargs=1, action='append',
@@ -424,7 +424,7 @@ def parse_args():
         nargs=1, action='append',
         help="ACME-provided token")
     parser_cleanchallenge.add_argument(
-        'extra',
+        '_extra',
         nargs='*',
         metavar='...',
         action='append',
@@ -433,7 +433,7 @@ def parse_args():
     parser_deploycert = subparsers.add_parser(
         'deploy_cert',
         help='deploy certificate obtained from ACME (UNIMPLEMENTED)')
-    parser_deploycert.set_defaults(func=deploy_cert, parser=parser_deploycert)
+    parser_deploycert.set_defaults(_func=deploy_cert, _parser=parser_deploycert)
     parser_deploycert.add_argument(
         'domain',
         nargs=1, action='append',
@@ -462,7 +462,7 @@ def parse_args():
     parser_unchangedcert = subparsers.add_parser(
         'unchanged_cert',
         help='unchanged certificate obtained from ACME (IGNORED)')
-    parser_unchangedcert.set_defaults(func=unchanged_cert, parser=parser_unchangedcert)
+    parser_unchangedcert.set_defaults(_func=unchanged_cert, _parser=parser_unchangedcert)
     parser_unchangedcert.add_argument(
         'domain',
         nargs=1, action='append',
@@ -486,12 +486,12 @@ def parse_args():
 
     args = parser.parse_args()
     try:
-        while(args.extra[0]):
-            extra=args.extra[0]
-            args.extra=[]
-            args=args.parser.parse_args(extra, args)
+        while(args._extra[0]):
+            extra=args._extra[0]
+            args._extra=[]
+            args=args._parser.parse_args(extra, args)
     except AttributeError:
-        # no 'extra' attribute in this sub-parser
+        # no '_extra' attribute in this sub-parser
         pass
 
     verbosity = args.verbose - args.quiet
@@ -503,7 +503,7 @@ def parse_args():
     set_verbosity(verbosity)
 
     cfg = read_config(args)
-    return (args.func, cfg)
+    return (args._func, cfg)
 
 
 if __name__ == '__main__':

--- a/dnspython-hook.py
+++ b/dnspython-hook.py
@@ -534,5 +534,6 @@ def parse_args():
 if __name__ == '__main__':
     (fun, cfgs) = parse_args()
     for cfg in cfgs:
+        set_verbosity(cfg['verbosity'])
         fun(cfg)
     sys.exit(0)


### PR DESCRIPTION
this implements [hook-chain support](https://github.com/lukas2511/dehydrated/blob/master/docs/hook_chain.md), which allows to deploy/clean multiple challenges in a single go.

it also adds rudimentary support to call a `post_<hookname>` script (with the call semantics defined by dehydrated for hooks), which is mainly useful to restart servers in the `deploy_cert` stage.