### PR TITLE
updates to new dehydrated-hooks and dns-rewriting feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following parameters can be set:
 - `key_name` name of the key to use for authentication with the DNS server (**required**, see [below](#using-an-extra-key-file))
 - `key_secret` the base64-encoded key secret (**required**, see [below](#using-an-extra-key-file))
 - `key_algorithm` the hashing algorithm of the key (default: *hmac-md5*)
+- `dns_rewrite` a regular expression to rewrite the DNS record used to publish the challenge (default: no rewriting)
 
 A complete example can be found in the `dehydrated-hook-ddns-tsig.conf` file.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,15 @@ The script reads the name of this key file from the environmental variable `DDNS
 $ export DDNS_HOOK_KEY_FILE="path/to/key/file.key"
 ```
 
-The file must be formatted in an [rndc/bind](https://ftp.isc.org/isc/bind9/cur/9.9/doc/arm/man.rndc.conf.html) compatible way.
+The file must be formatted in an [rndc/bind](https://ftp.isc.org/isc/bind9/cur/9.9/doc/arm/man.rndc.conf.html) compatible way,
+e.g. like:
+
+``` isc
+key "testkey" {
+   secret "R3HI8P6BKw9ZwXwN3VZKuQ==";
+   algorithm = hmac-md5;
+};
+```
 
 Only when using *this* method for acquiring the key,
 you must have [iscpy](https://pypi.python.org/pypi/iscpy) installed.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This repository contains a python hook for the [dehydrated](https://github.com/l
 Download the files for installation
 
 ``` sh
-  $ git clone https://github.com/lukas2511/dehydrated.git
-  $ mkdir -p dehydrated/hooks/ddns-tsig
-  $ git clone https://github.com/eferdman/dehydrated-hook-ddns-tsig.git dehydrated/hooks/ddns-tsig
+$ git clone https://github.com/lukas2511/dehydrated.git
+$ mkdir -p dehydrated/hooks/ddns-tsig
+$ git clone https://github.com/eferdman/dehydrated-hook-ddns-tsig.git dehydrated/hooks/ddns-tsig
 ```
 
 ## Configuration
@@ -44,7 +44,7 @@ you can provide that information in an extra file.
 The script reads the name of this key file from the environmental variable `DDNS_HOOK_KEY_FILE`
 
 ``` sh
-  $ export DDNS_HOOK_KEY_FILE="path/to/key/file.key"
+$ export DDNS_HOOK_KEY_FILE="path/to/key/file.key"
 ```
 
 The file must be formatted in an [rndc/bind](https://ftp.isc.org/isc/bind9/cur/9.9/doc/arm/man.rndc.conf.html) compatible way.

--- a/dehydrated-hook-ddns-tsig.conf
+++ b/dehydrated-hook-ddns-tsig.conf
@@ -15,10 +15,10 @@
 ## verbosity of the script: use negative values to suppress more messages)
 #verbosity = 0
 
-## encryption key
-# you MUST have an encryption key to talk to a DNS-server.
-# if values are omitted from this config-file, they will instead be read
-# from the file specified in the DDNS_HOOK_KEY_FILE envvar.
+### encryption key
+##  you MUST have an encryption key to talk to a DNS-server.
+##  if values are omitted from this config-file, they will instead be read
+##  from the file specified in the DDNS_HOOK_KEY_FILE envvar.
 ## name of the key
 key_name = testkey
 ## base64-encoded value of the key
@@ -26,13 +26,24 @@ key_secret = "R3HI8P6BKw9ZwXwN3VZKuQ=="
 ## key-algorithm to use (bind9 only supports hmac-md5)
 #key_algorithm = hmac-md5
 
+## DNS record rewriting
+## If you generally use static zone files, and only have dynamic DNS enabled
+##   for a few other zones, you can setup a (static) CNAME record to point your
+##   _acme-challenge record into a dynamic zone.
+##   E.g. setting up a CNAME from _acme-challenge.domain.ext to
+##   domain.ext.dynamiczone.otherdomain.ext.
+##   This lets ACME check the challenge in a static zone, while only allowing
+##   dehydrated to update the dynamic entry.
+#dns_rewrite = s/^_acme-challenge\.(.+)$/\1.dynamiczone.otherdomain.ext/
+
+
 ## you can also call additional hook-scripts after each stage
 ## the configuration keys are 'post_<stagename>'
-#   the arguments (and stagenames) are as documented for 'dehydrated' hooks
+##   the arguments (and stagenames) are as documented for 'dehydrated' hooks
 #post_deploy_cert = /script/to/dehydrated_hooks/deploy_cert.sh
 
 ###################################################
-# you can override values for a given domain
+## you can override values for a given domain
 #[example.com]
 #name_server_ip = 127.0.0.1
 #key_name = samplekey

--- a/dehydrated-hook-ddns-tsig.py
+++ b/dehydrated-hook-ddns-tsig.py
@@ -600,6 +600,13 @@ def parse_args():
         'timestamp',
         nargs=1, action='append',
         help="time stamp")
+    parser_deploycert.add_argument(
+        '_extra',
+        nargs='*',
+        metavar='...',
+        action='append',
+        help="domain1 keyfile1 certfile1 fullchainfile1 chainfile1 timestamp1 ...",
+        )
 
     parser_unchangedcert = subparsers.add_parser(
         'unchanged_cert',
@@ -627,6 +634,13 @@ def parse_args():
         'chainfile',
         nargs=1, action='append',
         help="certificate chain")
+    parser_unchangedcert.add_argument(
+        '_extra',
+        nargs='*',
+        metavar='...',
+        action='append',
+        help="domain1 keyfile1 certfile1 fullchainfile1 chainfile1 ...",
+        )
 
     args = parser.parse_args()
     try:

--- a/dehydrated-hook-ddns-tsig.py
+++ b/dehydrated-hook-ddns-tsig.py
@@ -24,11 +24,15 @@
 #
 ############################################################################
 
-# callbacks
-# deploy_challenge <DOMAIN> <TOKEN_FILENAME> <TOKEN_VALUE>
-# clean_challenge <DOMAIN> <FILENAME> <TOKEN_VALUE>
-# deploy_cert <DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAIN> <CHAINFILE> <TIMESTAMP>
-# unchanged_cert DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAINFILE> <CHAINFILE>
+# callbacks:
+# *deploy_challenge <DOMAIN> <TOKEN_FILENAME> <TOKEN_VALUE>.
+# *clean_challenge <DOMAIN> <FILENAME> <TOKEN_VALUE>.
+# deploy_cert <DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAIN> <CHAINFILE> <TIMESTAMP>.
+# unchanged_cert DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAINFILE> <CHAINFILE>.
+# invalid_challenge <DOMAIN> <RESPONSE>.
+# request_failure <STATUSCODE> <REASON> <REQTYPE>.
+# startup_hook.
+# exit_hook.
 
 
 import os

--- a/dehydrated-hook-ddns-tsig.py
+++ b/dehydrated-hook-ddns-tsig.py
@@ -27,7 +27,7 @@
 # callbacks:
 # *deploy_challenge <DOMAIN> <TOKEN_FILENAME> <TOKEN_VALUE>.
 # *clean_challenge <DOMAIN> <FILENAME> <TOKEN_VALUE>.
-# deploy_cert <DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAIN> <CHAINFILE> <TIMESTAMP>.
+# deploy_cert <DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAIN> <CHAINFILE> <TSTAMP>.
 # unchanged_cert DOMAIN> <KEYFILE> <CERTFILE> <FULLCHAINFILE> <CHAINFILE>.
 # invalid_challenge <DOMAIN> <RESPONSE>.
 # request_failure <STATUSCODE> <REASON> <REQTYPE>.
@@ -203,7 +203,9 @@ Return True if the record could be verified, false otherwise.
                       for _ in resolver.query(domain_name, rtype)]
         except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer) as e:
             # probably not there yet...
-            logger.debug("Unable to verify %s record for %s @ %s" % (rtype, domain_name, ns))
+            logger.debug(
+                "Unable to verify %s record for %s @ %s" %
+                (rtype, domain_name, ns))
             if not invert:
                 return False
 
@@ -251,7 +253,10 @@ def create_txt_record(
             update.add(head, ttl, 'TXT', token)
             logger.debug(str(update))
             try:
-                response = dns.query.udp(update, name_server_ip, timeout=timeout)
+                response = dns.query.udp(
+                    update,
+                    name_server_ip,
+                    timeout=timeout)
                 rcode = response.rcode()
                 logger.debug(" + Creating TXT record %s -> %s returned %s" % (
                     head, tail,
@@ -260,7 +265,9 @@ def create_txt_record(
                     return dn
             except DNSException as err:
                 logger.debug("", exc_info=True)
-                logger.error(err)
+                logger.error(
+                    "Error creating TXT record %s %s: %s" %
+                    (head, tail, err))
 
     name = None
     for dn in domain_names:
@@ -325,8 +332,9 @@ def delete_txt_record(
 
     def _do_delete_txt(dn):
         domain_list = dn.split('.')
-        logger.info(' + Deleting TXT record "%s" for the domain %s'
-                % (token, dn))
+        logger.info(
+            ' + Deleting TXT record "%s" for the domain %s' % (token, dn)
+            )
 
         for i in range(1, len(domain_list)):
             head = '.'.join(domain_list[:i])
@@ -339,7 +347,10 @@ def delete_txt_record(
             update.delete(head, txt_record)
             logger.debug(str(update))
             try:
-                response = dns.query.udp(update, name_server_ip, timeout=timeout)
+                response = dns.query.udp(
+                    update,
+                    name_server_ip,
+                    timeout=timeout)
                 rcode = response.rcode()
                 logger.debug(" + Removing TXT record %s -> %s returned %s" % (
                     head, tail,
@@ -348,7 +359,9 @@ def delete_txt_record(
                     return dn
             except DNSException as err:
                 logger.debug("", exc_info=True)
-                logger.error("Error deleting TXT record %s %s" % (head, tail))
+                logger.error(
+                    "Error deleting TXT record %s %s: %s" %
+                    (head, tail, err))
 
     name = None
     for dn in domain_names:
@@ -433,12 +446,14 @@ def unchanged_cert(cfg):
         'unchanged_cert', cfg,
         ['domain', 'keyfile', 'certfile', 'fullchainfile', 'chainfile'])
 
+
 # challenge response has failed
 def invalid_challenge(cfg):
     """challenge response failed [no-op]"""
     return post_hook(
         'invalid_challenge', cfg,
         ['domain', 'response'])
+
 
 # something went wrong when talking to the ACME-server
 def request_failure(cfg):
@@ -447,10 +462,12 @@ def request_failure(cfg):
         'request_failure', cfg,
         ['statuscode', 'reason', 'reqtype'])
 
+
 def startup_hook(cfg):
     """Called at beginning of cron-command, for some initial tasks
 (e.g. start a webserver)"""
     return post_hook('request_failure', cfg, [])
+
 
 def exit_hook(cfg):
     """Called at end of cron command, to do some cleanup"""
@@ -464,7 +481,7 @@ def rewriter(sed):
         cmd, pattern, repl, options = re.split(r'(?<![^\\]\\)/', sed)
         if cmd != 's':
             logger.warn(
-                "invalid string-transformation '%s', must be 's/PATTERN/REPL/'",
+                "invalid string-transformation '%s', must be 's/PTRN/REPL/'",
                 sed)
             return None
         regex = re.compile(pattern)
@@ -518,7 +535,9 @@ def ensure_config_dns(cfg):
     if "name_server_ip" not in cfg:
         cfg["name_server_ip"] = defaults["name_server_ip"]
 
-    cfg["dns_rewrite"] = rewriter (cfg.get("dns_rewrite") or defaults.get("dns_rewrite"))
+    cfg["dns_rewrite"] = rewriter(
+        cfg.get("dns_rewrite")
+        or defaults.get("dns_rewrite"))
 
     return cfg
 
@@ -698,7 +717,7 @@ def parse_args():
         nargs='*',
         metavar='...',
         action='append',
-        help="domain1 keyfile1 certfile1 fullchainfile1 chainfile1 timestamp1 ...",
+        help="domain1 keyfile1 certfile1 fullchainfile1 chainfile1 ts1 ...",
         )
 
     parser_unchangedcert = subparsers.add_parser(

--- a/dehydrated-hook-ddns-tsig.py
+++ b/dehydrated-hook-ddns-tsig.py
@@ -376,8 +376,8 @@ def clean_challenge(cfg):
 
 
 # callback to deploy the obtained certificate
-# (currently unimplemented)
 def deploy_cert(cfg):
+    """deploy obtained certificates [no-op]"""
     post_hook(
         'deploy_cert', cfg,
         ['domain',
@@ -388,6 +388,7 @@ def deploy_cert(cfg):
 # callback when the certificate has not changed
 # (currently unimplemented)
 def unchanged_cert(cfg):
+    """called when certificated is still valid [no-op]"""
     post_hook(
         'unchanged_cert', cfg,
         ['domain', 'keyfile', 'certfile', 'fullchainfile', 'chainfile'])
@@ -578,7 +579,7 @@ def parse_args():
 
     parser_deploycert = subparsers.add_parser(
         'deploy_cert',
-        help='deploy certificate obtained from ACME (UNIMPLEMENTED)')
+        help='deploy certificate obtained from ACME [NO-OP]')
     parser_deploycert.set_defaults(
         _func=deploy_cert,
         _parser=parser_deploycert)
@@ -616,7 +617,7 @@ def parse_args():
 
     parser_unchangedcert = subparsers.add_parser(
         'unchanged_cert',
-        help='unchanged certificate obtained from ACME (IGNORED)')
+        help='unchanged certificate obtained from ACME [NO-OP]')
     parser_unchangedcert.set_defaults(
         _func=unchanged_cert,
         _parser=parser_unchangedcert)

--- a/dehydrated-hook-ddns-tsig.py
+++ b/dehydrated-hook-ddns-tsig.py
@@ -93,6 +93,7 @@ def post_hook(name, cfg, args):
             callargs += [cfg[a]]
         logger.info(' + Calling post %s hook: %s' % (name, ' '.join(callargs)))
         subprocess.call(callargs)
+    return
 
 
 def get_key_algo(name='hmac-md5'):
@@ -359,7 +360,7 @@ def deploy_challenge(cfg):
         ttl=cfg["ttl"],
         sleep=cfg["wait"],
         )
-    post_hook('deploy_challenge', cfg, ['domain', 'tokenfile', 'token'])
+    return post_hook('deploy_challenge', cfg, ['domain', 'tokenfile', 'token'])
 
 
 # callback to clean the challenge from DNS
@@ -372,13 +373,13 @@ def clean_challenge(cfg):
         ttl=cfg["ttl"],
         sleep=cfg["wait"],
         )
-    post_hook('clean_challenge', cfg, ['domain', 'tokenfile', 'token'])
+    return post_hook('clean_challenge', cfg, ['domain', 'tokenfile', 'token'])
 
 
 # callback to deploy the obtained certificate
 def deploy_cert(cfg):
     """deploy obtained certificates [no-op]"""
-    post_hook(
+    return post_hook(
         'deploy_cert', cfg,
         ['domain',
          'keyfile', 'certfile',
@@ -389,7 +390,7 @@ def deploy_cert(cfg):
 # (currently unimplemented)
 def unchanged_cert(cfg):
     """called when certificated is still valid [no-op]"""
-    post_hook(
+    return post_hook(
         'unchanged_cert', cfg,
         ['domain', 'keyfile', 'certfile', 'fullchainfile', 'chainfile'])
 

--- a/dehydrated-hook-ddns-tsig.py
+++ b/dehydrated-hook-ddns-tsig.py
@@ -543,7 +543,8 @@ def parse_args():
         nargs='*',
         metavar='...',
         action='append',
-        help="domain1 tokenfile1 token1 ...")
+        help="domain1 tokenfile1 token1 ...",
+        )
 
     parser_cleanchallenge = subparsers.add_parser(
         'clean_challenge',
@@ -568,7 +569,8 @@ def parse_args():
         nargs='*',
         metavar='...',
         action='append',
-        help="domain1 tokenfile1 token1 ...")
+        help="domain1 tokenfile1 token1 ...",
+        )
 
     parser_deploycert = subparsers.add_parser(
         'deploy_cert',


### PR DESCRIPTION
dehydrated now has a couple more hooks, which makes `dehydrated-hook-ddns-tsig` fail (if one of the new hooks is called).
This PR adds all the currently used (but missing) hooks (it still requires that all the hooks are listed explicitely though).

The PR also includes a new feature `dns_rewrite` as requested in [Debian#873112](https://bugs.debian.org/873112), which allows  `dehydrated-hook-ddns-tsig` to be used if the main DNS-zones are static (without ddns support)