### PR TITLE
use IPv6 DNS Servers

### DIFF
--- a/dehydrated-hook-ddns-tsig.py
+++ b/dehydrated-hook-ddns-tsig.py
@@ -152,10 +152,13 @@ Return a list of nameserver IPs (might be empty)
     for i in range(0, len(name_list)):
         nameservers = []
         try:
-            for ns in [rdata.target.to_unicode()
-                       for rdata in dns.resolver.query('.'.join(name_list[i:]),
-                                                       'NS')]:
-                nameservers += [_.to_text() for _ in dns.resolver.query(ns)]
+            fqdn = '.'.join(name_list[i:])
+            for rdata in dns.resolver.query(fqdn, dns.rdatatype.NS):
+                ns = rdata.target.to_unicode()
+                nsL = [] 
+                nsL.extend([_.to_text() for _ in dns.resolver.query(ns)]) # default type: A
+                nsL.extend([_.to_text() for _ in dns.resolver.query(ns, rdtype=dns.rdatatype.AAAA)])
+                nameservers.append(nsL)
         except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN) as e:
             continue
         if nameservers:
@@ -197,7 +200,7 @@ Return True if the record could be verified, false otherwise.
                        rtype,
                        rdata if rdata is not None else "*",
                        ns))
-        resolver.nameservers = [ns]
+        resolver.nameservers = ns
         answer = []
         try:
             answer = [_.to_text().strip('"'+"'")


### PR DESCRIPTION
If a domain has 2 public nameservers, lets say ns1.domain.example
and ns2.domain.example, the hook now requests A and AAAA records for NS entries.
These are saved to a list
```
  [
   [ 'IPv4#1 of ns1',  'IPv4#2 of ns1', 'IPv6#1 of ns1'],
   [ 'IPv4#1 of ns2',  'IPv4#2 of ns2', 'IPv6#1 of ns2'],
  ]
```
When checking the TXT-record dnspython can check any IP of this server.