### PR TITLE
Read DNS-Key Algorithm from Keyfile

### DIFF
--- a/dehydrated-hook-ddns-tsig.py
+++ b/dehydrated-hook-ddns-tsig.py
@@ -138,9 +138,10 @@ Alternatively set key_name/key_secret in the configuration file""")
 
     # Grab the secret key
     secret = parsed_key_file.values()[0]['secret'].strip('\"')
+    algorithm = parsed_key_file.values()[0]['algorithm'].strip('\"')
     f.close()
 
-    return (key_name, secret)
+    return (key_name, algorithm, secret)
 
 
 def query_NS_record(domain_name):
@@ -502,6 +503,7 @@ def ensure_config_dns(cfg):
 """
     # (str)key_name
     # (str)key_secret
+    # (str)key_algorithm
     # (str)name_server_ip
     # (int)ttl
     # (float)wait
@@ -510,7 +512,7 @@ def ensure_config_dns(cfg):
         key_name = cfg["key_name"]
         key_secret = cfg["key_secret"]
     except KeyError:
-        (key_name, key_secret) = get_isc_key()
+        (key_name, key_algorithm, key_secret) = get_isc_key()
 
     keyringd = {key_name: key_secret}
     keyring = dns.tsigkeyring.from_text(keyringd)
@@ -519,7 +521,7 @@ def ensure_config_dns(cfg):
     try:
         algo = cfg["key_algorithm"]
     except KeyError:
-        algo = ""
+        algo = key_algorithm if key_algorithm else ""
     algo = get_key_algo(algo)
     cfg["keyalgorithm"] = algo
 


### PR DESCRIPTION
When adding a key from a file via Environment the algorithm
should be read from the keyfile.

  `DDNS_HOOK_KEY_FILE=/etc/named/hostname.key`

which has the same format, as a isc-bind key:

```
key "hostname.fqdn" {
  algorithm hmac-sha256;
  secret "YXYA4uXvycCJ6AB0jhc7wA==";
};
```

Signed-off-by: Björn Lässig <b.laessig@pengutronix.de>