### PR TITLE
Provide default values for key_*

### DIFF
--- a/dehydrated-hook-ddns-tsig.py
+++ b/dehydrated-hook-ddns-tsig.py
@@ -511,6 +511,10 @@ def ensure_config_dns(cfg):
     # (int)ttl
     # (float)wait
 
+    key_name = None
+    key_secret = None
+    key_algorithm = None
+
     try:
         key_name = cfg["key_name"]
         key_secret = cfg["key_secret"]


### PR DESCRIPTION
otherwise the script would bail out if key_algorithm is not present in the config...

this fixes a regression in #25 
