### PR TITLE
BIND9 hmac-sha256

### DIFF
--- a/dehydrated-hook-ddns-tsig.conf
+++ b/dehydrated-hook-ddns-tsig.conf
@@ -23,7 +23,7 @@
 key_name = testkey
 ## base64-encoded value of the key
 key_secret = "R3HI8P6BKw9ZwXwN3VZKuQ=="
-## key-algorithm to use (bind9 only supports hmac-md5)
+## key-algorithm to use (use, eg. `tsig-keygen' to easily generate a BIND9 hmac-sha256 key)
 #key_algorithm = hmac-md5
 
 ## DNS record rewriting


### PR DESCRIPTION
BIND9 supports more than just MD5 TSIG keys; also note use of  easy `tsig-keygen(8)`