### PR TITLE
resolver.nameservers may need to be a list of strings

### DIFF
--- a/dehydrated-hook-ddns-tsig.py
+++ b/dehydrated-hook-ddns-tsig.py
@@ -201,7 +201,7 @@ Return True if the record could be verified, false otherwise.
                        rtype,
                        rdata if rdata is not None else "*",
                        ns))
-        resolver.nameservers = ns
+        resolver.nameservers = [ns]
         answer = []
         try:
             answer = [_.to_text().strip('"'+"'")


### PR DESCRIPTION
I don't know if this might instead not be an issue I've only got in my setup, but (1) this line broke my setup for me (with the regrettably non-helpful error message "DNS timeout", leading to some hours of debugging), (2) in other places in this hook, it _is_ handled as a list of strings, suggesting that's indeed what it should be (but the lack of open issues about this and the age of the line of code is confusing - although possibly #30 may be related).

Turning it into a list of strings fixed my problems.

Feel free to accept or reject as you see fit - you're a much better judge if this is just my setup's problem and would break things for other people, or if this is a fix of a general problem! :)