### PR TITLE
use '==' instead of 'is' for testing rcode values

### DIFF
--- a/dehydrated-hook-ddns-tsig.py
+++ b/dehydrated-hook-ddns-tsig.py
@@ -266,7 +266,7 @@ def create_txt_record(
                 logger.debug(" + Creating TXT record %s -> %s returned %s" % (
                     head, tail,
                     dns.rcode.to_text(rcode)))
-                if rcode is dns.rcode.NOERROR:
+                if rcode == dns.rcode.NOERROR:
                     return dn
             except DNSException as err:
                 logger.debug("", exc_info=True)
@@ -360,7 +360,7 @@ def delete_txt_record(
                 logger.debug(" + Removing TXT record %s -> %s returned %s" % (
                     head, tail,
                     dns.rcode.to_text(rcode)))
-                if rcode is dns.rcode.NOERROR:
+                if rcode == dns.rcode.NOERROR:
                     return dn
             except DNSException as err:
                 logger.debug("", exc_info=True)


### PR DESCRIPTION
seems like with newer pydns, the type (of at least dns.rcode.*)
has changed to some enum, so the "is" comparision always
evaulates to `False`
.
this in turn makes the script fail (as it wrongly believes that
adding/deleting the TXT record failed